### PR TITLE
Switch positions components, subsections, and sections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'jquery-rails', '3.1.4'
 gem 'sass-rails', '5.0.6'
 gem 'uglifier', '2.7.2'
 gem 'meta-tags', '2.3.1'
+gem 'acts_as_list', '0.8.0'
 
 group :development, :staging, :test do
   gem 'ffaker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    acts_as_list (0.8.0)
+      activerecord (>= 3.0)
     addressable (2.4.0)
     annotate (2.7.1)
       activerecord (>= 3.2, < 6.0)
@@ -290,6 +292,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (= 0.9.4)
+  acts_as_list (= 0.8.0)
   annotate
   awesome_print
   better_errors

--- a/app/controllers/api/admins/components_controller.rb
+++ b/app/controllers/api/admins/components_controller.rb
@@ -26,6 +26,15 @@ class Api::Admins::ComponentsController < Api::Admins::BaseController
     end
   end
 
+  def switch_position
+    if @component.switch(switch_position_params)
+      render json: @component, serializer: ComponentSerializer
+    else
+      error_response(nil, 'Invalid position given')
+    end
+  end
+
+
   private
 
   def component_params
@@ -36,5 +45,9 @@ class Api::Admins::ComponentsController < Api::Admins::BaseController
       :position,
       :subsection_id,
     )
+  end
+
+  def switch_position_params
+    params.require(:component).permit(:position)
   end
 end

--- a/app/controllers/api/admins/sections_controller.rb
+++ b/app/controllers/api/admins/sections_controller.rb
@@ -25,6 +25,14 @@ class Api::Admins::SectionsController < Api::Admins::BaseController
     end
   end
 
+  def switch_position
+    if @section.switch(switch_position_params)
+      render json: @section, serializer: SectionSerializer
+    else
+      error_response(nil, 'Invalid position given')
+    end
+  end
+
   private
 
   def section_params
@@ -33,5 +41,9 @@ class Api::Admins::SectionsController < Api::Admins::BaseController
       :course_id,
       :position
     )
+  end
+
+  def switch_position_params
+    params.require(:section).permit(:position)
   end
 end

--- a/app/controllers/api/admins/subsections_controller.rb
+++ b/app/controllers/api/admins/subsections_controller.rb
@@ -25,6 +25,15 @@ class Api::Admins::SubsectionsController < Api::Admins::BaseController
     end
   end
 
+  def switch_position
+    if @subsection.switch(switch_position_params)
+      render json: @subsection, serializer: SubsectionSerializer
+    else
+      error_response(nil, 'Invalid position given')
+    end
+  end
+
+
   private
 
   def subsection_params
@@ -33,5 +42,9 @@ class Api::Admins::SubsectionsController < Api::Admins::BaseController
       :section_id,
       :position
     )
+  end
+
+  def switch_position_params
+    params.require(:subsection).permit(:position)
   end
 end

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -17,9 +17,16 @@ class Component < ActiveRecord::Base
 
   validates :component_type, presence: true
   validates :content_url, presence: true
-  validates :position, presence: true
   validates :subsection_id, presence: true
   validates :position, uniqueness: { scope: :subsection_id }
 
   belongs_to :subsection
+  acts_as_list scope: :subsection
+
+  def switch(params)
+    new_position = params[:position].presence || position
+    return false if new_position >= subsection.components.size or new_position < 0
+    insert_at(new_position)
+    true
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -12,7 +12,7 @@
 class Course < ActiveRecord::Base
   validates :name, :description, presence: true
 
-  has_many :sections
+  has_many :sections, -> { order(position: :asc) }
   has_many :code_courses
   has_many :codes, through: :code_courses
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -13,12 +13,12 @@
 class Section < ActiveRecord::Base
   validates :title, presence: true
   validates :course_id, presence: true
-  validates :position, presence: true
 
   validates :position, uniqueness: { scope: :course_id }
 
-  has_many :subsections
+  has_many :subsections, -> { order(position: :asc) }
   belongs_to :course
+  acts_as_list scope: :course
 
   def progress(user)
     n = 0.0
@@ -32,5 +32,12 @@ class Section < ActiveRecord::Base
     end
 
     return completed / n * 100
+  end
+
+  def switch(params)
+    new_position = params[:position].presence || position
+    return false if new_position >= course.sections.size or new_position < 0
+    insert_at(new_position)
+    true
   end
 end

--- a/app/models/subsection.rb
+++ b/app/models/subsection.rb
@@ -13,16 +13,23 @@
 class Subsection < ActiveRecord::Base
   validates :title, presence: true
   validates :section_id, presence: true
-  validates :position, presence: true
 
   validates :position, uniqueness: { scope: :section_id }
 
   belongs_to :section
+  acts_as_list scope: :section
 
-  has_many :components
+  has_many :components, -> { order(position: :asc) }
 
   def is_complete?(user)
     subsection_progress = SubsectionProgress.find_by({ student_id: user.id, subsection_id: id })
     subsection_progress.blank? ? false : subsection_progress.completed
+  end
+
+  def switch(params)
+    new_position = params[:position].presence || position
+    return false if new_position >= section.subsections.size or new_position < 0
+    insert_at(new_position)
+    true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,8 +35,18 @@ Rails.application.routes.draw do
     namespace :admins do
       resources :courses, only: [:create, :update, :destroy], shallow: true do
         resources :sections, only: [:create, :update, :destroy] do
+          member do
+            post :switch_position
+          end
           resources :subsections, only: [:create, :update, :destroy] do
-            resources :components, only: [:create, :update, :destroy]
+            member do
+              post :switch_position
+            end
+            resources :components, only: [:create, :update, :destroy] do
+              member do
+                post :switch_position
+              end
+            end
           end
         end
       end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-# This file should contain all the record creation needed to seed the database with its default values.
+  # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #
 # Examples:
@@ -49,22 +49,19 @@ def create_courses
 
   sections = courses.map do |course|
     5.times.map do |n|
-      course.sections.create title: FFaker::Movie.title,
-                             position: n
+      course.sections.create title: FFaker::Movie.title
     end
   end.flatten
 
   subsections = sections.map do |section|
     5.times.map do |n|
-      section.subsections.create title: FFaker::CheesyLingo.title,
-                                     position: n
+      section.subsections.create title: FFaker::CheesyLingo.title
     end
   end.flatten
 
   subsections.map do |subsection|
     3.times.map do |n|
       subsection.components.create component_type: 0,
-                                   position: n,
                                    content_url: 'https://docs.google.com/presentation/d/1Bi_nOT9xuBrb07dquBM6IZZJ3iTOJmj15adkF3IVqFw/pub?start=false&loop=false&delayms=3000'
     end
   end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -30,11 +30,6 @@ RSpec.describe Component, type: :model do
         expect(component.valid?).to be false
       end
 
-      it 'no position' do
-        component.position = nil
-        expect(component.valid?).to be false
-      end
-
       it 'no subsection_id' do
         component.subsection_id = nil
         expect(component.valid?).to be false

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -28,11 +28,6 @@ RSpec.describe Section, type: :model do
       expect(section.valid?).to be false
     end
 
-    it 'has no position' do
-      section.position = nil
-      expect(section.valid?).to be false
-    end
-
     it 'is a duplicate position from the same course' do
       other_section.course_id = valid_section.course_id
       other_section.position = valid_section.position

--- a/spec/models/subsection_spec.rb
+++ b/spec/models/subsection_spec.rb
@@ -28,11 +28,6 @@ RSpec.describe Subsection, type: :model do
       expect(subsection.valid?).to be false
     end
 
-    it 'has no position' do
-      subsection.position = nil
-      expect(subsection.valid?).to be false
-    end
-
     it 'is a duplicate position from the same course' do
       other_subsection.section_id = valid_subsection.section_id
       other_subsection.position = valid_subsection.position


### PR DESCRIPTION
Use acts_as_list to switch positions for components, subsections, and sections. Added switch methods and acts_as_list attribute to all 3 models, switch_position for all 3 in routes, and modified controllers to have switch_position_params and methods. #73 