### PR TITLE
Limit course access to courses student is enrolled in

### DIFF
--- a/app/assets/javascripts/course/components/CoursePage.js
+++ b/app/assets/javascripts/course/components/CoursePage.js
@@ -16,8 +16,8 @@ class CoursePage extends React.Component {
     return (
       <div>
         <h1>This is a course page</h1>
-        <CourseSidebar course_id={this.props.course_id} />
         <ParentComponent component={this.component_params}/>
+        <CourseSidebar id={this.props.routeParams.id}/>
       </div>
     )
   }

--- a/app/assets/javascripts/course/components/CourseSidebar.js
+++ b/app/assets/javascripts/course/components/CourseSidebar.js
@@ -16,8 +16,6 @@ class CourseSidebar extends React.Component {
   constructor(props) {
     super(props)
 
-    this.id = this.props.course_id
-
     this.state = {
       courseSidebar: {}
     }
@@ -26,7 +24,7 @@ class CourseSidebar extends React.Component {
   }
 
   requestSidebar() {
-    const path = APIRoutes.getCourseSidebarPath(this.id)
+    const path = APIRoutes.getStudentCourseSidebarPath(this.props.id)
 
     request.get(path, (response) => {
       this.setState({ courseSidebar: response.course_sidebar })

--- a/app/assets/javascripts/shared/routes.js
+++ b/app/assets/javascripts/shared/routes.js
@@ -54,7 +54,7 @@ class APIRoutes {
 
   static getAdminPath(id)      { return APIRoutes.createRoute(`admins/${id}`) }
   static getStudentPath(id)    { return APIRoutes.createRoute(`students/${id}`) }
-  static getCourseOutlinePath(id) { return APIRoutes.createRoute(`courses/${id}/outline`) }
+  static getStudentCourseOutlinePath(id) { return APIRoutes.createRoute(`students/courses/${id}/outline`) }
   static getCourseSidebarPath(id) { return APIRoutes.createRoute(`courses/${id}/sidebar`) }
 
   static verifyCodePath()      { return APIRoutes.createRoute(`codes/verify`) }

--- a/app/assets/javascripts/shared/routes.js
+++ b/app/assets/javascripts/shared/routes.js
@@ -55,7 +55,7 @@ class APIRoutes {
   static getAdminPath(id)      { return APIRoutes.createRoute(`admins/${id}`) }
   static getStudentPath(id)    { return APIRoutes.createRoute(`students/${id}`) }
   static getStudentCourseOutlinePath(id) { return APIRoutes.createRoute(`students/courses/${id}/outline`) }
-  static getCourseSidebarPath(id) { return APIRoutes.createRoute(`courses/${id}/sidebar`) }
+  static getStudentCourseSidebarPath(id) { return APIRoutes.createRoute(`students/courses/${id}/sidebar`) }
 
   static verifyCodePath()      { return APIRoutes.createRoute(`codes/verify`) }
 

--- a/app/assets/javascripts/students/components/CourseCard.js
+++ b/app/assets/javascripts/students/components/CourseCard.js
@@ -1,14 +1,32 @@
-import React from 'react'
+import React, { PropTypes } from 'react'
+import { Link } from 'react-router'
+
+import { ReactRoutes } from '../../shared/routes'
 
 class CourseCard extends React.Component {
+  disableLink(e) {
+    if (!this.props.course.is_enrolled) {
+      e.preventDefault()
+    }
+  }
+
   render() {
     return (
-      <div>
-        <h2>{this.props.course.name}</h2>
-        <p>{this.props.course.description}</p>
-      </div>
+      <Link onClick={this.disableLink.bind(this)}
+        to={ReactRoutes.courseOutlinePath(this.props.course.id)}>
+        <div>
+          <h2>{this.props.course.name}</h2>
+          <p>{this.props.course.description}</p>
+        </div>
+      </Link>
     )
   }
+}
+
+CourseCard.propTypes = {
+  course: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+    })
 }
 
 export default CourseCard

--- a/app/assets/javascripts/students/components/CourseList.js
+++ b/app/assets/javascripts/students/components/CourseList.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Link } from 'react-router'
 
 import { APIRoutes } from '../../shared/routes'
 import request from '../../shared/requests/request'
@@ -27,22 +26,29 @@ class CourseList extends React.Component {
     })
   }
 
-  renderCards() {
-    return this.state.courses.map((value) => {
+  renderCards(list) {
+    return list.map((value) => {
       return (
-        <Link
-          to={ReactRoutes.courseOutlinePath(value.id)}>
-          <CourseCard key={value.id} course={value} />
-        </Link>
+        <CourseCard key={value.id} course={value} />
       )
     })
   }
 
+  sortCards() {
+    return [this.state.courses.filter(function (course) { return course.is_enrolled}),
+      this.state.courses.sort(function(x, y) {return (x.is_enrolled === y.is_enrolled)? 0 : x.is_enrolled? -1 : 1})]
+  }
+
   render() {
+    var lists = this.sortCards()
+    var enrolledList = lists[0]
+    var allList = lists[1]
     return (
       <div>
-        <h1>Courses</h1>
-        <ol>{this.renderCards()}</ol>
+        <h1>Enrolled Courses</h1>
+        <ol>{this.renderCards(enrolledList)}</ol>
+        <h1>All Courses</h1>
+        <ol>{this.renderCards(allList)}</ol>
       </div>
     )
   }

--- a/app/assets/javascripts/students/components/CourseOutlinePage.js
+++ b/app/assets/javascripts/students/components/CourseOutlinePage.js
@@ -25,7 +25,7 @@ class CourseOutlinePage extends React.Component {
   }
 
   requestOutline() {
-    const path = APIRoutes.getCourseOutlinePath(this.id)
+    const path = APIRoutes.getStudentCourseOutlinePath(this.id)
 
     request.get(path, (response) => {
       console.log(response)

--- a/app/controllers/api/courses_controller.rb
+++ b/app/controllers/api/courses_controller.rb
@@ -1,16 +1,8 @@
 class Api::CoursesController < Api::BaseController
   load_and_authorize_resource
 
-  def show
-    render json: @course, serializer: CourseSerializer
-  end
-
   def edit
     render json: @course, serializer: CourseEditSerializer
-  end
-
-  def outline
-    render json: @course, user: current_user, serializer: CourseOutlineSerializer
   end
 
   def sidebar

--- a/app/controllers/api/courses_controller.rb
+++ b/app/controllers/api/courses_controller.rb
@@ -1,12 +1,12 @@
 class Api::CoursesController < Api::BaseController
   load_and_authorize_resource
 
-  def edit
-    render json: @course, serializer: CourseEditSerializer
+  def show
+    render json: @course, serializer: CourseSerializer
   end
 
-  def sidebar
-    render json: @course, user: current_user, serializer: CourseSidebarSerializer
+  def edit
+    render json: @course, serializer: CourseEditSerializer
   end
 
   def index

--- a/app/controllers/api/students/courses_controller.rb
+++ b/app/controllers/api/students/courses_controller.rb
@@ -8,4 +8,8 @@ class Api::Students::CoursesController < Api::Students::BaseController
   def outline
     render json: @course, user: current_user, serializer: CourseOutlineSerializer
   end
+
+  def sidebar
+    render json: @course, user: current_user, serializer: CourseSidebarSerializer
+  end
 end

--- a/app/controllers/api/students/courses_controller.rb
+++ b/app/controllers/api/students/courses_controller.rb
@@ -1,0 +1,11 @@
+class Api::Students::CoursesController < Api::Students::BaseController
+  load_and_authorize_resource
+
+  def show
+    render json: @course, serializer: CourseSerializer
+  end
+
+  def outline
+    render json: @course, user: current_user, serializer: CourseOutlineSerializer
+  end
+end

--- a/app/models/abilities/student_ability.rb
+++ b/app/models/abilities/student_ability.rb
@@ -2,6 +2,7 @@ class StudentAbility
   include CanCan::Ability
 
   def initialize(student)
+    puts 'asdfsfdasadffsadasdfasdfasdfdf'
     student ||= Student.new
 
     can [
@@ -11,5 +12,10 @@ class StudentAbility
       :update,
       :destroy,
     ], Student, id: student.id
+
+    can :show, Course do |course|
+      puts 'asfkasflkasdflkajsfhkjlsfhljasdf'
+      course.is_enrolled
+    end
   end
 end

--- a/app/models/abilities/student_ability.rb
+++ b/app/models/abilities/student_ability.rb
@@ -2,7 +2,6 @@ class StudentAbility
   include CanCan::Ability
 
   def initialize(student)
-    puts 'asdfsfdasadffsadasdfasdfasdfdf'
     student ||= Student.new
 
     can [
@@ -13,9 +12,8 @@ class StudentAbility
       :destroy,
     ], Student, id: student.id
 
-    can :show, Course do |course|
-      puts 'asfkasflkasdflkajsfhkjlsfhljasdf'
-      course.is_enrolled
+    can [:show, :outline, :sidebar], Course do |course|
+      course.is_enrolled?(student)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,11 @@ Rails.application.routes.draw do
     end
 
     namespace :students do
+      resources :courses, only: [:show] do
+        member do
+          get :outline
+        end
+      end
     end
 
     scope module: 'students' do
@@ -69,10 +74,7 @@ Rails.application.routes.draw do
       resources :admins, only: [:update]
     end
 
-    resources :courses, only: [:show, :index, :edit], shallow: true do
-      member do
-        get :outline
-      end
+    resources :courses, only: [:index, :edit], shallow: true do
       resources :sections, only: [] do
         resources :subsections, only: [] do
           resources :components, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,7 +75,7 @@ Rails.application.routes.draw do
       resources :admins, only: [:update]
     end
 
-    resources :courses, only: [:index, :show, :edit], shallow: true do
+    resources :courses, only: [:index, :edit], shallow: true do
       resources :sections, only: [] do
         resources :subsections, only: [] do
           resources :components, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
       resources :courses, only: [:show] do
         member do
           get :outline
+          get :sidebar
         end
       end
     end
@@ -74,18 +75,7 @@ Rails.application.routes.draw do
       resources :admins, only: [:update]
     end
 
-    resources :courses, only: [:index, :edit], shallow: true do
-      resources :sections, only: [] do
-        resources :subsections, only: [] do
-          resources :components, only: [:show]
-        end
-      end
-    end
-
-    resources :courses, only: [:show, :index], shallow: true do
-      member do
-        get :sidebar
-      end
+    resources :courses, only: [:index, :show, :edit], shallow: true do
       resources :sections, only: [] do
         resources :subsections, only: [] do
           resources :components, only: [:show]


### PR DESCRIPTION
Change CourseList and CourseCard to organize courses by courses student is enrolled in and disable link for courses student isn't enrolled in. Move routes for course outline and course sidebar under students courses for API. #94