### PR TITLE
Fixes course sidebar inactive states, working for now. Can simplify.

### DIFF
--- a/app/assets/javascripts/course/components/CoursePage.js
+++ b/app/assets/javascripts/course/components/CoursePage.js
@@ -168,6 +168,10 @@ class CoursePage extends React.Component {
       section.subsections[subsectionIndex]
 
     if (!this.isSubsectionCompleted(subsection)) {
+<<<<<<< aa46b0cd38a497a2a3d88d25f68814e022c7787c
+=======
+      // this.setState({ currentSubsection: subsection })
+>>>>>>> Refactors active checks to completedSubsectionIds set.
       this.state.completedSubsectionIds.add(nextSubsection.id)
     }
     this.displaySubsection(subsection.id, componentIndex)

--- a/app/assets/javascripts/course/components/CoursePage.js
+++ b/app/assets/javascripts/course/components/CoursePage.js
@@ -18,8 +18,7 @@ class CoursePage extends React.Component {
       courseSidebar: {}, // Use courseSidebar.current_subsection
       displayedSection: {},
       displayedSubsection: {},
-      currentSubsection: {},
-      completedSubsectionIds: new Set(),
+      activeSubsectionIds: new Set(),
       displayedComponent: {},
       nextDisabled: true
     }
@@ -105,7 +104,7 @@ class CoursePage extends React.Component {
     if (nextSubsection != null) {
       this.displaySubsection(nextSubsection.id, 0)
       if (!this.isSubsectionCompleted(nextSubsection)) {
-        this.state.completedSubsectionIds.add(nextSubsection.id)
+        this.state.activeSubsectionIds.add(nextSubsection.id)
       }
     } else {
       this.displayNextSection()
@@ -168,11 +167,7 @@ class CoursePage extends React.Component {
       section.subsections[subsectionIndex]
 
     if (!this.isSubsectionCompleted(subsection)) {
-<<<<<<< aa46b0cd38a497a2a3d88d25f68814e022c7787c
-=======
-      // this.setState({ currentSubsection: subsection })
->>>>>>> Refactors active checks to completedSubsectionIds set.
-      this.state.completedSubsectionIds.add(nextSubsection.id)
+      this.state.activeSubsectionIds.add(nextSubsection.id)
     }
     this.displaySubsection(subsection.id, componentIndex)
   }
@@ -234,30 +229,34 @@ class CoursePage extends React.Component {
     }
 
     request.post(path, componentParams, (response) => {
-      this.state.completedSubsectionIds.add(subsection.id)
+      this.state.activeSubsectionIds.add(subsection.id)
     }, (error) => {
       console.log(error)
     })
   }
 
   isSubsectionCompleted(subsection) {
-    return this.state.completedSubsectionIds.has(subsection.id)
+    return this.state.activeSubsectionIds.has(subsection.id)
   }
 
   requestSidebar() {
     const path = APIRoutes.getStudentCourseSidebarPath(this.props.routeParams.id)
+    var add = true
 
     request.get(path, (response) => {
       this.setState({ courseSidebar: response.course_sidebar })
-      this.setState({ currentSubsection: response.course_sidebar.current_subsection })
+      /* Adds all active subsections to set */
       response.course_sidebar.sections.forEach((section) => {
         section.subsections.forEach((subsection) => {
-          if (subsection.is_complete) {
-            this.state.completedSubsectionIds.add(subsection.id)
+          if (add) {
+            this.state.activeSubsectionIds.add(subsection.id)
+          }
+          if (!subsection.is_complete) {
+            add = false
           }
         })
       })
-      this.setState({ completedSubsectionIds: this.state.completedSubsectionIds })
+      this.setState({ activeSubsectionIds: this.state.activeSubsectionIds })
     }, (error) => {
       console.log(error)
     })
@@ -270,8 +269,7 @@ class CoursePage extends React.Component {
           <CourseSidebar
             courseSidebar={this.state.courseSidebar}
             displayedSubsection={this.state.displayedSubsection}
-            currentSubsection={this.state.currentSubsection}
-            completedSubsectionIds={this.state.completedSubsectionIds}
+            activeSubsectionIds={this.state.activeSubsectionIds}
             callback={this.displaySubsection}
           />
         </div>

--- a/app/assets/javascripts/course/components/CoursePage.js
+++ b/app/assets/javascripts/course/components/CoursePage.js
@@ -19,6 +19,7 @@ class CoursePage extends React.Component {
       displayedSection: {},
       displayedSubsection: {},
       activeSubsectionIds: new Set(),
+      activeSectionId: {},
       displayedComponent: {},
       nextDisabled: true
     }
@@ -41,7 +42,7 @@ class CoursePage extends React.Component {
   displaySubsection(id, componentIndex) {
     const path = APIRoutes.getSubsectionPath(id)
 
-  request.get(path, (response) => {
+    request.get(path, (response) => {
       const length = response.components.length
       const displayedSection = this.getDisplayedSection(response)
       const displayedComponent = componentIndex == -1 ?
@@ -184,9 +185,6 @@ class CoursePage extends React.Component {
   }
 
   isLastComponent(subsection, component) {
-    console.log('huh')
-    console.log(subsection.components)
-    console.log(component.position)
     return component.position == subsection.components.length
   }
 
@@ -242,6 +240,7 @@ class CoursePage extends React.Component {
   requestSidebar() {
     const path = APIRoutes.getStudentCourseSidebarPath(this.props.routeParams.id)
     var add = true
+    var lastSectionId = undefined
 
     request.get(path, (response) => {
       this.setState({ courseSidebar: response.course_sidebar })
@@ -250,13 +249,17 @@ class CoursePage extends React.Component {
         section.subsections.forEach((subsection) => {
           if (add) {
             this.state.activeSubsectionIds.add(subsection.id)
+            lastSectionId = section.id
           }
           if (!subsection.is_complete) {
             add = false
           }
         })
       })
-      this.setState({ activeSubsectionIds: this.state.activeSubsectionIds })
+      this.setState({
+        activeSectionId: lastSectionId,
+        activeSubsectionIds: this.state.activeSubsectionIds
+      })
     }, (error) => {
       console.log(error)
     })
@@ -270,6 +273,7 @@ class CoursePage extends React.Component {
             courseSidebar={this.state.courseSidebar}
             displayedSubsection={this.state.displayedSubsection}
             activeSubsectionIds={this.state.activeSubsectionIds}
+            activeSectionId={this.state.activeSectionId}
             callback={this.displaySubsection}
           />
         </div>

--- a/app/assets/javascripts/course/components/CoursePage.js
+++ b/app/assets/javascripts/course/components/CoursePage.js
@@ -195,7 +195,6 @@ class CoursePage extends React.Component {
   nextDisabled() {
     const component = this.state.displayedComponent
     const subsection_complete = this.state.displayedSubsection.is_complete
-    console.log(subsection_complete);
     if (subsection_complete) {
       return false
     } else if (component.component_type == 0 && component.audio_url == null) {

--- a/app/assets/javascripts/course/components/CourseSidebar.js
+++ b/app/assets/javascripts/course/components/CourseSidebar.js
@@ -20,6 +20,7 @@ class CourseSidebar extends React.Component {
           section={value}
           displayedSubsection={this.props.displayedSubsection}
           activeSubsectionIds={this.props.activeSubsectionIds}
+          activeSectionId={this.props.activeSectionId}
           callback={this.props.callback}
         />
       )

--- a/app/assets/javascripts/course/components/CourseSidebar.js
+++ b/app/assets/javascripts/course/components/CourseSidebar.js
@@ -32,6 +32,7 @@ class CourseSidebar extends React.Component {
           section={value}
           displayedSubsection={this.props.displayedSubsection}
           currentSubsection={this.props.currentSubsection}
+          completedSubsectionIds={this.props.completedSubsectionIds}
           sectionDisplayType={this.getSectionDisplayType(currentSectionIndex, index)}
           callback={this.props.callback}
         />

--- a/app/assets/javascripts/course/components/CourseSidebar.js
+++ b/app/assets/javascripts/course/components/CourseSidebar.js
@@ -12,42 +12,18 @@ import SectionSidebar from './SectionSidebar'
 
 class CourseSidebar extends React.Component {
 
-  getCurrentSectionIndex() {
-    var sectionIndex = -1
-    this.props.courseSidebar.sections.forEach((section, index) => {
-      var subsectionIds = section.subsections.map((subsection) => subsection.id)
-      if (_.contains(subsectionIds, this.props.currentSubsection.id)) {
-        sectionIndex = index
-      }
-    })
-    return sectionIndex
-  }
-
   renderSections() {
-    const currentSectionIndex = this.getCurrentSectionIndex()
-    return _.map(this.props.courseSidebar.sections, (value, index) => {
+    return _.map(this.props.courseSidebar.sections, (value) => {
       return (
         <SectionSidebar
           key={value.id}
           section={value}
           displayedSubsection={this.props.displayedSubsection}
-          currentSubsection={this.props.currentSubsection}
-          completedSubsectionIds={this.props.completedSubsectionIds}
-          sectionDisplayType={this.getSectionDisplayType(currentSectionIndex, index)}
+          activeSubsectionIds={this.props.activeSubsectionIds}
           callback={this.props.callback}
         />
       )
     })
-  }
-
-  getSectionDisplayType(currentSectionIndex, sectionIndex) {
-    if (sectionIndex > currentSectionIndex) {
-      return 'all-inactive'
-    } else if (sectionIndex === currentSectionIndex) {
-      return 'both'
-    } else {
-      return 'all-active'
-    }
   }
 
   renderInfo() {

--- a/app/assets/javascripts/course/components/SectionSidebar.js
+++ b/app/assets/javascripts/course/components/SectionSidebar.js
@@ -13,8 +13,6 @@ class SectionSidebar extends React.Component {
 
   constructor(props) {
     super(props)
-    console.log(props.activeSectionId)
-    console.log(this.props.section.id)
     this.state = {
       // isOpen: this.props.section.id == this.props.activeSectionId ? true : false
       isOpen: true
@@ -25,7 +23,6 @@ class SectionSidebar extends React.Component {
   toggleCollapse() {
     const isOpen = this.state.isOpen
     this.setState({ isOpen: !isOpen })
-    console.log(this.props.activeSectionId)
   }
 
   renderSubsections() {

--- a/app/assets/javascripts/course/components/SectionSidebar.js
+++ b/app/assets/javascripts/course/components/SectionSidebar.js
@@ -14,23 +14,6 @@ class SectionSidebar extends React.Component {
     super(props)
   }
 
-  getCurrentSubsectionIndex() {
-    return this.props.section.subsections.map((subsection) => subsection.id).indexOf(this.props.currentSubsection.id)
-  }
-
-  getSubsectionDisplayType(index) {
-    switch (this.props.sectionDisplayType) {
-      case 'all-inactive':
-        return 'inactive'
-      case 'both':
-        return index > this.getCurrentSubsectionIndex() ? 'inactive' : ''
-      case 'all-active':
-        return ''
-      default:
-        return ''
-    }
-  }
-
   renderSubsections() {
     return this.props.section.subsections.map((value, index) => {
       return (
@@ -38,9 +21,7 @@ class SectionSidebar extends React.Component {
           key={value.id}
           subsection={value}
           displayedSubsection={this.props.displayedSubsection}
-          currentSubsection={this.props.currentSubsection}
-          completedSubsectionIds={this.props.completedSubsectionIds}
-          subsectionDisplayType={_.bind(this.getSubsectionDisplayType, this, index)}
+          activeSubsectionIds={this.props.activeSubsectionIds}
           callback={this.props.callback}
         />
       )

--- a/app/assets/javascripts/course/components/SectionSidebar.js
+++ b/app/assets/javascripts/course/components/SectionSidebar.js
@@ -39,7 +39,8 @@ class SectionSidebar extends React.Component {
           subsection={value}
           displayedSubsection={this.props.displayedSubsection}
           currentSubsection={this.props.currentSubsection}
-          subsectionDisplayType={this.getSubsectionDisplayType(index)}
+          completedSubsectionIds={this.props.completedSubsectionIds}
+          subsectionDisplayType={_.bind(this.getSubsectionDisplayType, this, index)}
           callback={this.props.callback}
         />
       )

--- a/app/assets/javascripts/course/components/SectionSidebar.js
+++ b/app/assets/javascripts/course/components/SectionSidebar.js
@@ -2,6 +2,7 @@ import _ from 'underscore'
 
 import React from 'react'
 import { Link } from 'react-router'
+import Collapse from 'react-collapse'
 
 import { getUser } from '../../utils/user_helpers'
 import { RailsRoutes, ReactRoutes } from '../../shared/routes'
@@ -12,6 +13,19 @@ class SectionSidebar extends React.Component {
 
   constructor(props) {
     super(props)
+    console.log(props.activeSectionId)
+    console.log(this.props.section.id)
+    this.state = {
+      // isOpen: this.props.section.id == this.props.activeSectionId ? true : false
+      isOpen: true
+    }
+    this.toggleCollapse = this.toggleCollapse.bind(this)
+  }
+
+  toggleCollapse() {
+    const isOpen = this.state.isOpen
+    this.setState({ isOpen: !isOpen })
+    console.log(this.props.activeSectionId)
   }
 
   renderSubsections() {
@@ -31,10 +45,12 @@ class SectionSidebar extends React.Component {
   render() {
     return (
       <div className='sidebar-section-card'>
-        <div className='sidebar-section-title-container'>
+        <div className='sidebar-section-title-container' onClick={this.toggleCollapse}>
           <h2>{this.props.section.title}</h2>
         </div>
-        <ul>{this.renderSubsections()}</ul>
+        <Collapse isOpened={this.state.isOpen}>
+          <ul>{this.renderSubsections()}</ul>
+        </Collapse>
       </div>
     )
   }

--- a/app/assets/javascripts/course/components/SubsectionSidebar.js
+++ b/app/assets/javascripts/course/components/SubsectionSidebar.js
@@ -18,9 +18,7 @@ class SubsectionSidebar extends React.Component {
   }
 
   getInactive() {
-    console.log(this.props.completedSubsectionIds)
-    return this.props.completedSubsectionIds.has(this.props.subsection.id) ? '' : 'inactive'
-    // return this.props.completedSubsectionIds.is_complete ? '' : 'inactive'
+    return this.props.activeSubsectionIds.has(this.props.subsection.id) ? '' : 'inactive'
   }
 
   render() {

--- a/app/assets/javascripts/course/components/SubsectionSidebar.js
+++ b/app/assets/javascripts/course/components/SubsectionSidebar.js
@@ -18,12 +18,14 @@ class SubsectionSidebar extends React.Component {
   }
 
   getInactive() {
-    return this.props.completedSubsectionIds.is_complete ? '' : 'inactive'
+    console.log(this.props.completedSubsectionIds)
+    return this.props.completedSubsectionIds.has(this.props.subsection.id) ? '' : 'inactive'
+    // return this.props.completedSubsectionIds.is_complete ? '' : 'inactive'
   }
 
   render() {
     return (
-      <div className={`sidebar-subsection-card ${this.getActive()} ${this.props.subsectionDisplayType()}`}>
+      <div className={`sidebar-subsection-card ${this.getActive()} ${this.getInactive()}`}>
         <li onClick={_.partial(this.props.callback, this.props.subsection.id, 0)}>
           {this.props.subsection.title}
         </li>

--- a/app/assets/javascripts/course/components/SubsectionSidebar.js
+++ b/app/assets/javascripts/course/components/SubsectionSidebar.js
@@ -17,9 +17,13 @@ class SubsectionSidebar extends React.Component {
     return this.props.displayedSubsection.id == this.props.subsection.id ? 'active' : ''
   }
 
+  getInactive() {
+    return this.props.completedSubsectionIds.is_complete ? '' : 'inactive'
+  }
+
   render() {
     return (
-      <div className={`sidebar-subsection-card ${this.getActive()} ${this.props.subsectionDisplayType}`}>
+      <div className={`sidebar-subsection-card ${this.getActive()} ${this.props.subsectionDisplayType()}`}>
         <li onClick={_.partial(this.props.callback, this.props.subsection.id, 0)}>
           {this.props.subsection.title}
         </li>


### PR DESCRIPTION
I swear there is an easier way to keep track of inactive states by just maintaining a set of all the completed subsection ids on CourseSidebar but I tried a bunch of stuff and it still doesn't work that way. Need to look into when states are updated/loaded and whether there are other bugs with the logic on the page.