### PR TITLE
Don't allow delete/add when course is published

### DIFF
--- a/app/assets/javascripts/courseEdit/components/ComponentEdit.js
+++ b/app/assets/javascripts/courseEdit/components/ComponentEdit.js
@@ -171,6 +171,7 @@ class ComponentEdit extends React.Component {
           subsectionId={this.subsectionId}
           component={this.state.component}
           callback={this.onFormCompletion}
+          disabled={false}
         />
 
         <DeleteModal
@@ -178,6 +179,7 @@ class ComponentEdit extends React.Component {
           closeModal={this.closeDeleteModal}
           deleteFunction={this.deleteComponent}
           objectType='component'
+          disabled={this.props.course.isPublished}
         />
 
         <ChangeParentModal

--- a/app/assets/javascripts/courseEdit/components/ComponentForm.js
+++ b/app/assets/javascripts/courseEdit/components/ComponentForm.js
@@ -67,6 +67,40 @@ class ComponentForm extends React.Component {
     }
   }
 
+  renderItem() {
+    return (
+      <div className='flex flex-vertical add-component-container'>
+        <div className='input-label marginTopBot-xxs'>Type</div>
+        <div className='flex flex-horizontal'>
+          <button
+            className={`tab ${this.isActiveStyle(0)}`}
+            onClick={this.handleClick.bind(this, 0)}>
+            Slide
+          </button>
+          <button
+            className={`tab ${this.isActiveStyle(1)}`}
+            onClick={this.handleClick.bind(this, 1)}>
+            Quiz
+          </button>
+          <button
+            className={`tab ${this.isActiveStyle(2)}`}
+            onClick={this.handleClick.bind(this, 2)}>
+            Multimedia
+          </button>
+        </div>
+        <div className='component-form'>{this.renderForm()}</div>
+      </div>
+    )
+  }
+
+  renderDisabled() {
+    return (
+      <div>
+        This course has already been published - adding components is now disabled so that those already taking the course won't be affected. If you'd like to make changes, unpublish the course first.
+      </div>
+    )
+  }
+
   render() {
     return (
       <div>
@@ -87,27 +121,7 @@ class ComponentForm extends React.Component {
             </Modal.Dismiss>
           </Modal.Header>
           <Modal.Body>
-            <div className='flex flex-vertical add-component-container'>
-              <div className='input-label marginTopBot-xxs'>Type</div>
-              <div className='flex flex-horizontal'>
-                <button
-                  className={`tab ${this.isActiveStyle(0)}`}
-                  onClick={this.handleClick.bind(this, 0)}>
-                  Slide
-                </button>
-                <button
-                  className={`tab ${this.isActiveStyle(1)}`}
-                  onClick={this.handleClick.bind(this, 1)}>
-                  Quiz
-                </button>
-                <button
-                  className={`tab ${this.isActiveStyle(2)}`}
-                  onClick={this.handleClick.bind(this, 2)}>
-                  Multimedia
-                </button>
-              </div>
-              <div className='component-form'>{this.renderForm()}</div>
-            </div>
+            {this.props.disabled ? this.renderDisabled() : this.renderItem()}
           </Modal.Body>
           <Modal.Footer className='white'>
           </Modal.Footer>
@@ -125,7 +139,8 @@ ComponentForm.defaultProps = {
     audio_url: null,
     content_url: null,
     form_key: '',
-  }
+  },
+  disabled: false,
 }
 
 export default ComponentForm

--- a/app/assets/javascripts/courseEdit/components/CourseEditPage.js
+++ b/app/assets/javascripts/courseEdit/components/CourseEditPage.js
@@ -8,6 +8,7 @@ import { Images, convertImage } from '../../utils/helpers/image_helpers'
 import { snakeToCamel } from '../../utils/helpers/form_helpers'
 
 import InlineEditInput from '../../shared/components/forms/InlineEditInput'
+import SimpleModal from '../../shared/components/widgets/SimpleModal'
 
 import SectionEdit from './SectionEdit'
 import DeleteCourseModal from './DeleteCourseModal'
@@ -28,6 +29,7 @@ class CourseEditPage extends React.Component {
       forceOpen: false,
       isDeleteModalOpen: false,
       isReorderModalOpen: false,
+      isDisabledModalOpen: false,
     }
 
     this.createSection = this.createSection.bind(this)
@@ -41,6 +43,8 @@ class CourseEditPage extends React.Component {
     this.closeDeleteModal = this.closeDeleteModal.bind(this)
     this.openReorderModal = this.openReorderModal.bind(this)
     this.closeReorderModal = this.closeReorderModal.bind(this)
+    this.openDisabledModal = this.openDisabledModal.bind(this)
+    this.closeDisabledModal = this.closeDisabledModal.bind(this)
 
     this.onConfirmDelete = this.onConfirmDelete.bind(this)
     this.toggleIsPublished = this.toggleIsPublished.bind(this)
@@ -68,6 +72,14 @@ class CourseEditPage extends React.Component {
 
   closeReorderModal() {
     this.setState({ isReorderModalOpen: false })
+  }
+
+  openDisabledModal() {
+    this.setState({ isDisabledModalOpen: true })
+  }
+
+  closeDisabledModal() {
+    this.setState({ isDisabledModalOpen: false })
   }
 
   getCourse() {
@@ -163,6 +175,11 @@ class CourseEditPage extends React.Component {
   }
 
   createSection() {
+    if (this.state.course.isPublished) {
+      this.openDisabledModal()
+      return
+    }
+
     const path = APIRoutes.createSectionPath(this.id)
 
     request.post(path, {}, (response) => {
@@ -439,6 +456,16 @@ class CourseEditPage extends React.Component {
           onReorder={this.onReorder}
           disabled={this.state.course.isPublished}
         />
+
+        <SimpleModal
+          isModalOpen={this.state.isDisabledModalOpen}
+          closeModal={this.closeDisabledModal}
+          title='Add Section'
+        >
+          <div>
+            This course has already been published - adding sections is now disabled so that those already taking the course won't be affected. If you'd like to make changes, unpublish the course first.
+          </div>
+        </SimpleModal>
       </div>
     )
   }

--- a/app/assets/javascripts/courseEdit/components/SectionEdit.js
+++ b/app/assets/javascripts/courseEdit/components/SectionEdit.js
@@ -7,6 +7,7 @@ import { arrayMove } from 'react-sortable-hoc'
 import { APIRoutes } from '../../shared/routes'
 import { Images } from '../../utils/helpers/image_helpers'
 import request from '../../shared/requests/request'
+import SimpleModal from '../../shared/components/widgets/SimpleModal'
 
 import SubsectionEdit from './SubsectionEdit'
 import InlineEditInput from '../../shared/components/forms/InlineEditInput'
@@ -23,6 +24,7 @@ class SectionEdit extends React.Component {
       isOpen: false,
       openDeleteModal: false,
       isReorderModalOpen: false,
+      isDisabledModalOpen: false,
     }
 
     this.createSubsection = this.createSubsection.bind(this)
@@ -35,6 +37,8 @@ class SectionEdit extends React.Component {
     this.closeDeleteModal = this.closeDeleteModal.bind(this)
     this.openReorderModal = this.openReorderModal.bind(this)
     this.closeReorderModal = this.closeReorderModal.bind(this)
+    this.openDisabledModal = this.openDisabledModal.bind(this)
+    this.closeDisabledModal = this.closeDisabledModal.bind(this)
 
     this.onReorder = this.onReorder.bind(this)
   }
@@ -71,7 +75,20 @@ class SectionEdit extends React.Component {
     this.setState({ isReorderModalOpen: false })
   }
 
+  openDisabledModal() {
+    this.setState({ isDisabledModalOpen: true })
+  }
+
+  closeDisabledModal() {
+    this.setState({ isDisabledModalOpen: false })
+  }
+
   createSubsection() {
+    if (this.props.course.isPublished) {
+      this.openDisabledModal()
+      return
+    }
+
     const path = APIRoutes.createSubsectionPath(this.id)
 
     request.post(path, {}, (response) => {
@@ -233,6 +250,7 @@ class SectionEdit extends React.Component {
           closeModal={this.closeDeleteModal}
           deleteFunction={this.deleteSection}
           objectType='section'
+          disabled={this.props.course.isPublished}
         />
 
         <ReorderModal
@@ -243,6 +261,16 @@ class SectionEdit extends React.Component {
           onReorder={this.onReorder}
           disabled={this.props.course.isPublished}
         />
+
+        <SimpleModal
+          isModalOpen={this.state.isDisabledModalOpen}
+          closeModal={this.closeDisabledModal}
+          title='Add Subsection'
+        >
+          <div>
+            This course has already been published - adding subsections is now disabled so that those already taking the course won't be affected. If you'd like to make changes, unpublish the course first.
+          </div>
+        </SimpleModal>
       </div>
     )
   }

--- a/app/assets/javascripts/courseEdit/components/SubsectionEdit.js
+++ b/app/assets/javascripts/courseEdit/components/SubsectionEdit.js
@@ -307,6 +307,7 @@ class SubsectionEdit extends React.Component {
             closeModal={this.closeDeleteModal}
             deleteFunction={this.deleteSubsection}
             objectType="subsection"
+            disabled={this.props.course.isPublished}
           />
 
           <ChangeParentModal
@@ -327,6 +328,7 @@ class SubsectionEdit extends React.Component {
             closeModal={this.closeNewComponentForm}
             subsectionId={this.state.subsection.id}
             callback={this.onFormCompletion}
+            disabled={this.props.course.isPublished}
           />
           <button
             className='button button--white add-component-button'

--- a/app/assets/javascripts/shared/components/widgets/DeleteModal.js
+++ b/app/assets/javascripts/shared/components/widgets/DeleteModal.js
@@ -11,17 +11,11 @@ class DeleteModal extends React.Component {
     }
   }
 
-  render() {
+  renderDelete() {
     const confirmDeleteMessage = `Are you sure you want to delete this ${this.props.objectType}? This action cannot be undone.`
 
     return (
-      <Modal
-        show={this.props.openDeleteModal}
-        onHide={this.props.closeModal}
-      >
-        <Modal.Header>
-          <Modal.Title>Confirm Delete</Modal.Title>
-        </Modal.Header>
+      <div>
         <Modal.Body>
           {confirmDeleteMessage}
         </Modal.Body>
@@ -46,6 +40,33 @@ class DeleteModal extends React.Component {
             </div>
           </div>
         </Modal.Footer>
+      </div>
+    )
+  }
+
+  renderDisabled() {
+    return (
+      <div>
+        <Modal.Body>
+          This course has already been published - deleting is now disabled so that those already taking the course won't be affected. If you'd like to make changes, unpublish the course first.
+        </Modal.Body>
+        <Modal.Footer>
+        </Modal.Footer>
+      </div>
+    )
+  }
+
+  render() {
+    return (
+      <Modal
+        show={this.props.openDeleteModal}
+        onHide={this.props.closeModal}
+      >
+        <Modal.Header>
+          <Modal.Title>Confirm Delete</Modal.Title>
+        </Modal.Header>
+
+        {this.props.disabled ? this.renderDisabled() : this.renderDelete()}
       </Modal>
     )
   }
@@ -56,6 +77,7 @@ DeleteModal.propTypes = {
   closeModal: PropTypes.func.isRequired,
   deleteFunction: PropTypes.func.isRequired,
   objectType: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
 }
 
 export default DeleteModal


### PR DESCRIPTION
- Added SimpleModal for "can't add" message to CourseEdit and SectionEdit
- Added disabled prop and renderDisabled to ComponentEdit and DeleteModal for "can't add component" and "can't delete" messages