### PR TITLE
Upgrade EoL stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "RootsOfSuccess",
   "version": "0.0.1",
+  "engines": {
+    "node": "6.x"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Heroku cedar-14 is getting EoL'd in Nov 2020 so we need to redeploy the app on a newer stack.

Currently the node engine is not specified so it's trying to use `12.x` which is too new and incompatible. Fix node to `6.x` which is what was used in the last successful deploy.